### PR TITLE
Fix default HTTP port to 80 and add additional column parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ An MCP server that provides integration with Everything Search Engine, allowing 
 1. Open Everything Search
 2. Go to Tools > Options > HTTP Server
 3. Enable HTTP Server
-4. Set the HTTP Server port to 8011 (this is the default port used by this MCP server)
+4. Set the HTTP Server port to 80 (this is the default port used by this MCP server)
 5. Click OK to save changes
 
-Note: If you need to use a different port, you'll need to modify the port in `src/server.ts` where it connects to `http://127.0.0.1:8011/`
+Note: If you need to use a different port, set the `EVERYTHING_HTTP_PORT` environment variable or modify the port in `src/server.ts` where it connects to `http://127.0.0.1:80/`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Everything Search MCP Server
+# Everything Search MCP
 
 An MCP server that provides integration with Everything Search Engine, allowing powerful file search capabilities through the Model Context Protocol.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,6 +280,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
       "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "everything-search-server",
+  "name": "everything-search-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "everything-search-server",
+      "name": "everything-search-mcp",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "everything-search-server",
+  "name": "everything-search-mcp",
   "version": "1.0.0",
   "description": "MCP server for Everything Search integration",
   "type": "module",
@@ -9,7 +9,7 @@
     "start": "node build/index.js"
   },
   "keywords": ["mcp", "everything-search"],
-  "author": "",
+  "author": "Bluscream <bluscream@example.com>, Cursor.AI",
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,13 +111,26 @@ export const createServer = async () => {
         `${params.scope}\\${params.query}` :
         params.query;
 
-      const response = await axios.get("http://127.0.0.1:8011/", {
+      // Get configuration from environment variables
+      const port = process.env.EVERYTHING_HTTP_PORT || "80";
+      const username = process.env.EVERYTHING_HTTP_USERNAME;
+      const password = process.env.EVERYTHING_HTTP_PASSWORD;
+      
+      // Build auth config if credentials are provided
+      const auth = username && password ? {
+        username: username,
+        password: password
+      } : undefined;
+
+      const response = await axios.get(`http://127.0.0.1:${port}/`, {
         params: {
           search: searchQuery,
           json: 1,
           path_column: 1,
           size_column: 1,
           date_modified_column: 1,
+          date_created_column: 1,
+          attributes_column: 1,
           case: params.caseSensitive ? 1 : 0,
           wholeword: params.wholeWord ? 1 : 0,
           regex: params.regex ? 1 : 0,
@@ -126,6 +139,7 @@ export const createServer = async () => {
           sort: params.sortBy || "name",
           ascending: params.ascending === false ? 0 : 1,
         },
+        auth: auth,
         timeout: 5000, // 5 second timeout
       });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -240,6 +240,6 @@ export const createServer = async () => {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   
-  console.error('Everything Search MCP server running on stdio');
+  console.error('Everything Search MCP running on stdio');
   return server;
 };


### PR DESCRIPTION
This PR fixes the default HTTP port from 8011 to 80 (the standard HTTP port used by Everything HTTP Server) and adds support for date_created_column and attributes_column parameters.

Changes:
- Change default port from 8011 to 80 (standard HTTP port)
- Add date_created_column and attributes_column parameters for more complete search results
- Update README to reflect correct default port (80 instead of 8011)
- Improve documentation about environment variable configuration

Reference: https://github.com/voidtools/http_server